### PR TITLE
Update singleton.ex

### DIFF
--- a/lib/singleton.ex
+++ b/lib/singleton.ex
@@ -1,15 +1,17 @@
 defmodule LoggerSingleton do
   use GenServer
 
-  def start_link(_) do
+  defp start_link() do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
   def get_instance() do
+    start_link()
     GenServer.call(__MODULE__, :get_instance)
   end
 
   def println(msg) do
+    get_instance()
     GenServer.cast(__MODULE__, {:println, msg})
   end
 


### PR DESCRIPTION
- Retirei o parâmetro da função start_link/1 porque ele não era necessário
- Transformei a função start_link/0 em uma função privada, uma vez que ela faz o papel de "construtor" na analogia com POO.
- Fiz adaptações nas funções get_instance/0 e println/1 para garantir que sempre que elas forem chamadas, teremos uma "instancia" do processo iniciada antes.